### PR TITLE
feat: :sparkles: Implement debouncing for search input in DataTableHe…

### DIFF
--- a/packages/browser/core-hooks/index.ts
+++ b/packages/browser/core-hooks/index.ts
@@ -1,2 +1,3 @@
+export { default as useDebounce } from "./useDebounce";
 export { default as useFirstMount } from "./useFirstMount";
 export { default as useUpdateEffect } from "./useUpdateEffect";

--- a/packages/browser/core-hooks/useDebounce/index.ts
+++ b/packages/browser/core-hooks/useDebounce/index.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-const DEFAULT_DELAY = 500;
+const DEFAULT_DELAY = 200;
 
 const useDebounce = <T>(
   debounceResolutionCallback: (value: T) => void,
@@ -9,23 +9,19 @@ const useDebounce = <T>(
   const [debouncedValue, setDebouncedValue] = useState<T | undefined>(
     undefined
   );
-  const updateDebouncedValue = (value: T) => {
-    setDebouncedValue(value);
-  };
 
   useEffect(() => {
     const timeoutId = setTimeout(() => {
-      if (debouncedValue !== undefined) {
+      if (debouncedValue !== undefined)
         debounceResolutionCallback(debouncedValue);
-      }
     }, delay);
 
     return () => {
       clearTimeout(timeoutId);
     };
-  }, [debouncedValue, delay, debounceResolutionCallback]);
+  }, [debouncedValue, delay]);
 
-  return updateDebouncedValue;
+  return setDebouncedValue;
 };
 
 export default useDebounce;

--- a/packages/browser/core-hooks/useDebounce/index.ts
+++ b/packages/browser/core-hooks/useDebounce/index.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+
+const DEFAULT_DELAY = 500;
+
+const useDebounce = <T>(
+  debounceResolutionCallback: (value: T) => void,
+  delay: number = DEFAULT_DELAY
+) => {
+  const [debouncedValue, setDebouncedValue] = useState<T | undefined>(
+    undefined
+  );
+  const updateDebouncedValue = (value: T) => {
+    setDebouncedValue(value);
+  };
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      if (debouncedValue !== undefined) {
+        debounceResolutionCallback(debouncedValue);
+      }
+    }, delay);
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, [debouncedValue, delay, debounceResolutionCallback]);
+
+  return updateDebouncedValue;
+};
+
+export default useDebounce;

--- a/packages/browser/core-hooks/useDebounce/index.ts
+++ b/packages/browser/core-hooks/useDebounce/index.ts
@@ -3,17 +3,14 @@ import { useEffect, useState } from "react";
 const DEFAULT_DELAY = 200;
 
 const useDebounce = <T>(
-  debounceResolutionCallback: (value: T) => void,
+  debounceResolutionCallback: (value: T | undefined) => void,
   delay: number = DEFAULT_DELAY
 ) => {
-  const [debouncedValue, setDebouncedValue] = useState<T | undefined>(
-    undefined
-  );
+  const [debouncedValue, setDebouncedValue] = useState<T | undefined>();
 
   useEffect(() => {
     const timeoutId = setTimeout(() => {
-      if (debouncedValue !== undefined)
-        debounceResolutionCallback(debouncedValue);
+      debounceResolutionCallback(debouncedValue);
     }, delay);
 
     return () => {

--- a/packages/browser/data-table/InternalUncontrolledDataTable/hooks/useUncontrolledDataTable.ts
+++ b/packages/browser/data-table/InternalUncontrolledDataTable/hooks/useUncontrolledDataTable.ts
@@ -79,9 +79,12 @@ export const useUncontrolledDataTable = <T>({
     searchParams.get(UncontrolledDataTableURLParams.KEYWORD)
   );
 
-  const handleKeywordDebounced = (tempKeyword: string) => {
-    if (tempKeyword.trim())
-      searchParams.set(UncontrolledDataTableURLParams.KEYWORD, tempKeyword);
+  const handleKeywordDebounced = (debouncedKeyword: string) => {
+    if (debouncedKeyword.trim())
+      searchParams.set(
+        UncontrolledDataTableURLParams.KEYWORD,
+        debouncedKeyword
+      );
     else searchParams.delete(UncontrolledDataTableURLParams.KEYWORD);
     setSearchParams(searchParams);
     syncData(searchParams);
@@ -89,9 +92,9 @@ export const useUncontrolledDataTable = <T>({
 
   const debounceValue = useDebounce(handleKeywordDebounced);
 
-  const onKeywordChange = (tempKeyword: string) => {
-    setKeyword(tempKeyword);
-    debounceValue(tempKeyword);
+  const onKeywordChange = (newKeyWord: string) => {
+    setKeyword(newKeyWord);
+    debounceValue(newKeyWord);
   };
   const { limit, sortField, sortDirection } = useMemo(
     () => extractQueryParams(searchParams),

--- a/packages/browser/data-table/InternalUncontrolledDataTable/hooks/useUncontrolledDataTable.ts
+++ b/packages/browser/data-table/InternalUncontrolledDataTable/hooks/useUncontrolledDataTable.ts
@@ -79,22 +79,25 @@ export const useUncontrolledDataTable = <T>({
     searchParams.get(UncontrolledDataTableURLParams.KEYWORD)
   );
 
-  const handleKeywordDebounced = (debouncedKeyword: string) => {
-    if (debouncedKeyword.trim())
+  const updateSearchParamsAndSyncData = (
+    debouncedKeyword: string | undefined
+  ) => {
+    if (debouncedKeyword !== undefined && debouncedKeyword.trim()) {
       searchParams.set(
         UncontrolledDataTableURLParams.KEYWORD,
         debouncedKeyword
       );
-    else searchParams.delete(UncontrolledDataTableURLParams.KEYWORD);
+    } else searchParams.delete(UncontrolledDataTableURLParams.KEYWORD);
+
     setSearchParams(searchParams);
     syncData(searchParams);
   };
 
-  const debounceValue = useDebounce(handleKeywordDebounced);
+  const updateDebouncedKeyword = useDebounce(updateSearchParamsAndSyncData);
 
-  const onKeywordChange = (newKeyWord: string) => {
-    setKeyword(newKeyWord);
-    debounceValue(newKeyWord);
+  const onKeywordChange = (newKeyword: string) => {
+    setKeyword(newKeyword);
+    updateDebouncedKeyword(newKeyword);
   };
   const { limit, sortField, sortDirection } = useMemo(
     () => extractQueryParams(searchParams),

--- a/packages/browser/data-table/InternalUncontrolledDataTable/hooks/useUncontrolledDataTable.ts
+++ b/packages/browser/data-table/InternalUncontrolledDataTable/hooks/useUncontrolledDataTable.ts
@@ -1,6 +1,6 @@
 import { useImperativeHandle, useMemo, useState } from "react";
 
-import { useFirstMount } from "core-hooks";
+import { useDebounce, useFirstMount } from "core-hooks";
 import { IPaginatedResult } from "shared-types/IPaginatedResult";
 import { SortDirection } from "shared-types/SortDirection";
 
@@ -75,15 +75,24 @@ export const useUncontrolledDataTable = <T>({
     setSearchParams(searchParams);
     syncData(searchParams);
   };
+  const [keyword, setKeyword] = useState(
+    searchParams.get(UncontrolledDataTableURLParams.KEYWORD)
+  );
 
-  const onKeywordChange = (keyword: string) => {
-    if (keyword.trim())
-      searchParams.set(UncontrolledDataTableURLParams.KEYWORD, keyword);
+  const handleKeywordDebounced = (tempKeyword: string) => {
+    if (tempKeyword.trim())
+      searchParams.set(UncontrolledDataTableURLParams.KEYWORD, tempKeyword);
     else searchParams.delete(UncontrolledDataTableURLParams.KEYWORD);
     setSearchParams(searchParams);
     syncData(searchParams);
   };
 
+  const debounceValue = useDebounce(handleKeywordDebounced);
+
+  const onKeywordChange = (tempKeyword: string) => {
+    setKeyword(tempKeyword);
+    debounceValue(tempKeyword);
+  };
   const { limit, sortField, sortDirection } = useMemo(
     () => extractQueryParams(searchParams),
     [searchParams]
@@ -133,6 +142,6 @@ export const useUncontrolledDataTable = <T>({
     limit,
     loading,
     onKeywordChange,
-    keyword: searchParams.get(UncontrolledDataTableURLParams.KEYWORD),
+    keyword,
   };
 };

--- a/packages/browser/data-table/InternalUncontrolledDataTable/hooks/useUncontrolledDataTable.ts
+++ b/packages/browser/data-table/InternalUncontrolledDataTable/hooks/useUncontrolledDataTable.ts
@@ -93,11 +93,11 @@ export const useUncontrolledDataTable = <T>({
     syncData(searchParams);
   };
 
-  const updateDebouncedKeyword = useDebounce(updateSearchParamsAndSyncData);
+  const debounceKeyword = useDebounce(updateSearchParamsAndSyncData);
 
   const onKeywordChange = (newKeyword: string) => {
     setKeyword(newKeyword);
-    updateDebouncedKeyword(newKeyword);
+    debounceKeyword(newKeyword);
   };
   const { limit, sortField, sortDirection } = useMemo(
     () => extractQueryParams(searchParams),


### PR DESCRIPTION

### Description:
Add a debouncing mechanism to the search input field (RawInput) within the DataTableHeader component to optimize performance. This enhancement reduces the frequency of calls to the onKeywordChange handler, improving the overall user experience during typing.

### Fixes: #98 